### PR TITLE
Protobuf compilers: setters return `void`.

### DIFF
--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -64,7 +64,6 @@ module Tapioca
         class Field < T::Struct
           prop :name, String
           prop :type, String
-          prop :setter_type, String
           prop :init_type, String
           prop :default, String
         end
@@ -167,7 +166,6 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                setter_type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Hash[#{key_type}, #{value_type}]))",
                 default: "Google::Protobuf::Map.new(#{default_args.join(", ")})"
               )
@@ -181,7 +179,6 @@ module Tapioca
               Field.new(
                 name: descriptor.name,
                 type: type,
-                setter_type: type,
                 init_type: "T.nilable(T.any(#{type}, T::Array[#{elem_type}]))",
                 default: "Google::Protobuf::RepeatedField.new(#{default_args.join(", ")})"
               )
@@ -192,7 +189,6 @@ module Tapioca
             Field.new(
               name: descriptor.name,
               type: type,
-              setter_type: type,
               init_type: "T.nilable(#{type})",
               default: "nil"
             )
@@ -215,7 +211,7 @@ module Tapioca
 
           klass.create_method(
             "#{field.name}=",
-            parameters: [create_param("value", type: field.setter_type)],
+            parameters: [create_param("value", type: field.type)],
             return_type: "void"
           )
 

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -216,7 +216,7 @@ module Tapioca
           klass.create_method(
             "#{field.name}=",
             parameters: [create_param("value", type: field.setter_type)],
-            return_type: field.type
+            return_type: "void"
           )
 
           field

--- a/lib/tapioca/compilers/dsl/protobuf.rb
+++ b/lib/tapioca/compilers/dsl/protobuf.rb
@@ -131,7 +131,7 @@ module Tapioca
         def type_of(descriptor)
           case descriptor.type
           when :enum
-            "Symbol"
+            "T.any(Symbol, Integer)"
           when :message
             descriptor.subtype.msgclass.name
           when :int32, :int64, :uint32, :uint64
@@ -192,8 +192,8 @@ module Tapioca
             Field.new(
               name: descriptor.name,
               type: type,
-              setter_type: descriptor.type == :enum ? "T.any(#{type}, Integer)" : type,
-              init_type: descriptor.type == :enum ? "T.nilable(T.any(#{type}, Integer))" : "T.nilable(#{type})",
+              setter_type: type,
+              init_type: "T.nilable(#{type})",
               default: "nil"
             )
           end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -68,13 +68,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Integer) }
           def customer_id; end
 
-          sig { params(value: Integer).returns(Integer) }
+          sig { params(value: Integer).void }
           def customer_id=(value); end
 
           sig { returns(Integer) }
           def shop_id; end
 
-          sig { params(value: Integer).returns(Integer) }
+          sig { params(value: Integer).void }
           def shop_id=(value); end
         end
       RBI
@@ -105,7 +105,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(String) }
           def events; end
 
-          sig { params(value: String).returns(String) }
+          sig { params(value: String).void }
           def events=(value); end
         end
       RBI
@@ -139,7 +139,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::UInt64Value) }
           def cart_item_index; end
 
-          sig { params(value: Google::Protobuf::UInt64Value).returns(Google::Protobuf::UInt64Value) }
+          sig { params(value: Google::Protobuf::UInt64Value).void }
           def cart_item_index=(value); end
         end
       RBI
@@ -179,7 +179,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).void }
           def value_type=(value); end
         end
       RBI
@@ -230,7 +230,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Symbol) }
           def value_type; end
 
-          sig { params(value: T.any(Symbol, Integer)).returns(Symbol) }
+          sig { params(value: T.any(Symbol, Integer)).void }
           def value_type=(value); end
         end
       RBI
@@ -264,13 +264,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::RepeatedField[Integer]) }
           def customer_ids; end
 
-          sig { params(value: Google::Protobuf::RepeatedField[Integer]).returns(Google::Protobuf::RepeatedField[Integer]) }
+          sig { params(value: Google::Protobuf::RepeatedField[Integer]).void }
           def customer_ids=(value); end
 
           sig { returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
           def indices; end
 
-          sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).returns(Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]) }
+          sig { params(value: Google::Protobuf::RepeatedField[Google::Protobuf::UInt64Value]).void }
           def indices=(value); end
         end
       RBI
@@ -304,13 +304,13 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { returns(Google::Protobuf::Map[String, Integer]) }
           def customers; end
 
-          sig { params(value: Google::Protobuf::Map[String, Integer]).returns(Google::Protobuf::Map[String, Integer]) }
+          sig { params(value: Google::Protobuf::Map[String, Integer]).void }
           def customers=(value); end
 
           sig { returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
           def stores; end
 
-          sig { params(value: Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]).returns(Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]) }
+          sig { params(value: Google::Protobuf::Map[String, Google::Protobuf::UInt64Value]).void }
           def stores=(value); end
         end
       RBI
@@ -345,47 +345,47 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
       rbi_output = rbi_for(:Cart)
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: T::Boolean).returns(T::Boolean) }
+        sig { params(value: T::Boolean).void }
         def bool_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: String).returns(String) }
+        sig { params(value: String).void }
         def byte_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def customer_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def item_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Float).returns(Float) }
+        sig { params(value: Float).void }
         def money_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Float).returns(Float) }
+        sig { params(value: Float).void }
         def number_value=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: Integer).returns(Integer) }
+        sig { params(value: Integer).void }
         def shop_id=(value); end
       RBI
 
       assert_includes(rbi_output, indented(<<~RBI, 2))
-        sig { params(value: String).returns(String) }
+        sig { params(value: String).void }
         def string_value=(value); end
       RBI
     end

--- a/spec/tapioca/compilers/dsl/protobuf_spec.rb
+++ b/spec/tapioca/compilers/dsl/protobuf_spec.rb
@@ -176,7 +176,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Symbol) }
+          sig { returns(T.any(Symbol, Integer)) }
           def value_type; end
 
           sig { params(value: T.any(Symbol, Integer)).void }
@@ -227,7 +227,7 @@ class Tapioca::Compilers::Dsl::ProtobufSpec < DslSpec
           sig { params(value_type: T.nilable(T.any(Symbol, Integer))).void }
           def initialize(value_type: nil); end
 
-          sig { returns(Symbol) }
+          sig { returns(T.any(Symbol, Integer)) }
           def value_type; end
 
           sig { params(value: T.any(Symbol, Integer)).void }


### PR DESCRIPTION
### Motivation

https://github.com/Shopify/tapioca/pull/607 had some feedback about the need for generics for setter methods to return the correct type. This PR attempts to address that feedback (by avoiding the problem).

### Implementation

Ruby and Sorbet will evaluate assignment expressions or explicit calls to setter methods to the assigned value, regardless of what the method returns.

Some Protobuf setters accept multiple types (e.g. enum setters accept `T.any(Symbol, Integer)`) and while it is possible to express the idea that the return type matches the input type using generics, for all practical purposes it's equivalent to use `void` in an RBI definition.

Concrete examples here: https://github.com/Shopify/tapioca/pull/607#issuecomment-1196370225

### Tests

Tests updated 👍 

